### PR TITLE
fixed typo in Exercise 7.7 in notation for set of all functions from …

### DIFF
--- a/sections/sec_07.tex
+++ b/sections/sec_07.tex
@@ -608,7 +608,7 @@
   Show that the sets $D$ and $E$ of Exercise~7.5 have the same cardinality.
 }
 \sol{
-  Throughout what follows let $A^B$ denote the set of all functions from set $A$ to set $B$.
+  Throughout what follows let $A^B$ denote the set of all functions from set $B$ to set $A$.
 
   \begin{lem}\label{lem:countun:expin}
     If there is an injection from $A_1$ to $A_2$ with $A_2 \neq \es$, and an injection from $B_1$ to $B_2$, then there is also an injection from $A_1^{B_1}$ to $A_2^{B_2}$.


### PR DESCRIPTION
…one set to another (specifically the notation is described the wrong way around)