### PR TITLE
removed misleading commentary in solution of Exercise 7.4

### DIFF
--- a/sections/sec_07.tex
+++ b/sections/sec_07.tex
@@ -307,11 +307,6 @@
     }
     which is assumed to have a finite number of solutions.
     So let $X_\vq$ be the finite set real numbers that are solutions.
-    (We note that the polynomial corresponding to the vector $\vq = (0,\ldots,0) \in \rats^n$ becomes $0=0$ so that any real number $x$ satisfies it.
-    Similarly the polynomial corresponding to $\vq = (q_1, 0, \ldots, 0) \in \rats^n$ for nonzero $q_1$ corresponds to the equation $q_1 = 0$, which has no solutions.
-    Of course $X_\vq = \es$ is still finite in this case.
-    For the infinite-solution case we could simply remove the zero vector from $\rats^n$ without changing the argument in any substantial way.
-    This is also taken care of if we really do assume that \emph{any} polynomial has a finite number of solutions as we are evidently doing here.)
 
     Now, we clearly have that $\rats^n$ is countable by Theorem~7.6 since it is a finite product of countable sets (since it was shown in Exercise~7.1 that $\rats$ is countable).
     Thus the set $A_n = \bigcup_{\vq \in \rats^n} X_\vq$ is countable by Theorem~7.5 since it is a countable union of finite (and therefore countable) sets.


### PR DESCRIPTION
The entire commentary/explanatory text within the parenthesis in the solution of Exercise 7.4 is premised on an erroneous assumption. In particular what is said at the beginning "we note that the polynomial corresponding to the vector q=(0,...,0)" is wrong.